### PR TITLE
Added Staff approve and reject booking actions

### DIFF
--- a/frontend/src/components/BookingActionModal.js
+++ b/frontend/src/components/BookingActionModal.js
@@ -1,0 +1,87 @@
+import React from 'react';
+
+const BookingActionModal = ({
+  show,
+  actionType,
+  selectedBooking,
+  notes,
+  onNotesChange,
+  onClose,
+  onSubmit,
+  submitting,
+  getServiceName,
+  getStudentName,
+}) => {
+  if (!show || !selectedBooking) return null;
+
+  const isApprove = actionType === 'approve';
+
+  return (
+    <div
+      className="modal-overlay"
+      data-testid="booking-action-modal-overlay"
+      onClick={onClose}
+    >
+      <div
+        className="modal"
+        data-testid="booking-action-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h3>{isApprove ? 'Approve Booking' : 'Reject Booking'}</h3>
+          <button
+            className="close-btn"
+            onClick={onClose}
+            disabled={submitting}
+            aria-label="Close modal"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <p className="booking-info">
+            <strong>{getServiceName(selectedBooking)}</strong> —{' '}
+            {getStudentName(selectedBooking)}
+          </p>
+
+          <div className="form-group">
+            <label htmlFor="approval-notes">Additional Notes (Optional)</label>
+            <textarea
+              id="approval-notes"
+              value={notes}
+              onChange={(e) => onNotesChange(e.target.value)}
+              placeholder="Add any notes about this approval or rejection..."
+              rows="4"
+              disabled={submitting}
+            />
+          </div>
+
+          <div className="modal-actions">
+            <button
+              className="btn-cancel"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+
+            <button
+              className={isApprove ? 'btn-approve' : 'btn-reject'}
+              onClick={onSubmit}
+              disabled={submitting}
+            >
+              {submitting
+                ? 'Submitting...'
+                : isApprove
+                ? 'Approve Booking'
+                : 'Reject Booking'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BookingActionModal;

--- a/frontend/src/pages/StaffDashboard.js
+++ b/frontend/src/pages/StaffDashboard.js
@@ -8,105 +8,103 @@ const StaffDashboard = () => {
   const [bookings, setBookings] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [selectedBooking, setSelectedBooking] = useState(null);
-  const [notes, setNotes] = useState('');
-  const [showModal, setShowModal] = useState(false);
-  const [actionType, setActionType] = useState('');
   const [staffInfo, setStaffInfo] = useState(null);
 
   useEffect(() => {
-    // Get staff info from localStorage
     const token = localStorage.getItem('token');
     const user = localStorage.getItem('user');
-    
+
     if (!token || !user) {
       navigate('/login');
       return;
     }
 
-    const userData = JSON.parse(user);
-    if (userData.role !== 'staff') {
-      navigate('/');
-      return;
-    }
+    try {
+      const userData = JSON.parse(user);
 
-    setStaffInfo(userData);
-    fetchPendingBookings(userData.id);
+      if (userData.role !== 'staff') {
+        navigate('/');
+        return;
+      }
+
+      setStaffInfo(userData);
+      fetchPendingBookings(userData.id, token);
+    } catch (err) {
+      console.error('Failed to parse stored user data:', err);
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      navigate('/login');
+    }
   }, [navigate]);
 
-  const fetchPendingBookings = async (staffId) => {
+  const fetchPendingBookings = async (staffId, token) => {
     try {
       setLoading(true);
-      const token = localStorage.getItem('token');
+
       const response = await axios.get(
         `http://localhost:8080/api/approval/staff/${staffId}/pending`,
         {
-          headers: { Authorization: `Bearer ${token}` }
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
         }
       );
-      // Handle both array and {data: array} response formats
-      const bookingsData = Array.isArray(response.data) ? response.data : (response.data.data || []);
+
+      const bookingsData = Array.isArray(response.data)
+        ? response.data
+        : response.data?.data || [];
+
       setBookings(bookingsData);
       setError('');
     } catch (err) {
-      const errorMsg = err.response?.data?.error || 'Failed to load pending bookings';
+      console.error('Failed to load pending bookings:', err);
+      const errorMsg =
+        err.response?.data?.error || 'Failed to load pending bookings';
       setError(errorMsg);
-      console.error(err);
+      setBookings([]);
     } finally {
       setLoading(false);
     }
   };
 
-  const handleApprove = (booking) => {
-    setSelectedBooking(booking);
-    setActionType('approve');
-    setNotes('');
-    setShowModal(true);
-  };
-
-  const handleReject = (booking) => {
-    setSelectedBooking(booking);
-    setActionType('reject');
-    setNotes('');
-    setShowModal(true);
-  };
-
-  const submitAction = async () => {
-    try {
-      const token = localStorage.getItem('token');
-      const endpoint = actionType === 'approve' 
-        ? `/api/approval/bookings/${selectedBooking.id}/approve`
-        : `/api/approval/bookings/${selectedBooking.id}/reject`;
-
-      await axios.put(
-        `http://localhost:8080${endpoint}`,
-        { 
-          status: actionType === 'approve' ? 'approved' : 'rejected',
-          approvalNotes: notes,
-          staffId: staffInfo.id
-        },
-        {
-          headers: { Authorization: `Bearer ${token}` }
-        }
-      );
-
-      setShowModal(false);
-      setSelectedBooking(null);
-      fetchPendingBookings(staffInfo.id);
-    } catch (err) {
-      setError(`Failed to ${actionType} booking`);
-      console.error(err);
-    }
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    navigate('/login');
   };
 
   const formatDate = (dateString) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+    if (!dateString) return 'N/A';
+
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) return 'N/A';
+
+    return date.toLocaleString('en-US', {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
       hour: '2-digit',
-      minute: '2-digit'
+      minute: '2-digit',
     });
+  };
+
+  const getServiceName = (booking) => {
+    return booking.service?.name || booking.serviceName || 'Service Not Available';
+  };
+
+  const getStudentName = (booking) => {
+    if (booking.user?.firstName || booking.user?.lastName) {
+      return `${booking.user?.firstName || ''} ${booking.user?.lastName || ''}`.trim();
+    }
+    return booking.studentName || 'N/A';
+  };
+
+  const getStudentEmail = (booking) => {
+    return booking.user?.email || booking.email || 'N/A';
+  };
+
+  const getStudentPhone = (booking) => {
+    return booking.user?.phone || booking.phone || 'N/A';
   };
 
   return (
@@ -114,16 +112,12 @@ const StaffDashboard = () => {
       <div className="dashboard-header">
         <div>
           <h1>Staff Dashboard</h1>
-          <p className="welcome-text">Welcome, {staffInfo?.firstName} {staffInfo?.lastName}</p>
+          <p className="welcome-text">
+            Welcome, {staffInfo?.firstName} {staffInfo?.lastName}
+          </p>
         </div>
-        <button 
-          className="logout-btn"
-          onClick={() => {
-            localStorage.removeItem('token');
-            localStorage.removeItem('user');
-            navigate('/login');
-          }}
-        >
+
+        <button className="logout-btn" onClick={handleLogout}>
           Logout
         </button>
       </div>
@@ -132,7 +126,7 @@ const StaffDashboard = () => {
 
       <div className="bookings-section">
         <div className="section-header">
-          <h2>Pending Approvals</h2>
+          <h2>Pending Bookings</h2>
           <span className="badge">{bookings.length}</span>
         </div>
 
@@ -141,117 +135,58 @@ const StaffDashboard = () => {
         ) : bookings.length === 0 ? (
           <div className="empty-state">
             <p>No pending bookings</p>
-            <p className="secondary">All bookings have been reviewed</p>
+            <p className="secondary">There are currently no bookings awaiting review.</p>
           </div>
         ) : (
           <div className="bookings-grid">
             {bookings.map((booking) => (
               <div key={booking.id} className="booking-card">
                 <div className="booking-header">
-                  <h3 className="service-name">{booking.service?.name}</h3>
+                  <h3 className="service-name">{getServiceName(booking)}</h3>
                   <span className="status-badge pending">Pending</span>
                 </div>
 
                 <div className="booking-details">
                   <div className="detail-item">
                     <span className="label">Student Name:</span>
-                    <span className="value">{booking.user?.firstName} {booking.user?.lastName}</span>
+                    <span className="value">{getStudentName(booking)}</span>
                   </div>
+
                   <div className="detail-item">
                     <span className="label">Email:</span>
-                    <span className="value">{booking.user?.email}</span>
+                    <span className="value">{getStudentEmail(booking)}</span>
                   </div>
+
                   <div className="detail-item">
                     <span className="label">Phone:</span>
-                    <span className="value">{booking.user?.phone || 'N/A'}</span>
+                    <span className="value">{getStudentPhone(booking)}</span>
                   </div>
+
                   <div className="detail-item">
                     <span className="label">Start Time:</span>
                     <span className="value">{formatDate(booking.startTime)}</span>
                   </div>
+
                   <div className="detail-item">
                     <span className="label">End Time:</span>
                     <span className="value">{formatDate(booking.endTime)}</span>
                   </div>
+
                   <div className="detail-item">
                     <span className="label">Reason:</span>
                     <span className="value">{booking.notes || 'N/A'}</span>
                   </div>
+
                   <div className="detail-item">
                     <span className="label">Requested:</span>
                     <span className="value">{formatDate(booking.createdAt)}</span>
                   </div>
-                </div>
-
-                <div className="booking-actions">
-                  <button 
-                    className="btn-reject"
-                    onClick={() => handleReject(booking)}
-                  >
-                    Reject
-                  </button>
-                  <button 
-                    className="btn-approve"
-                    onClick={() => handleApprove(booking)}
-                  >
-                    Approve
-                  </button>
                 </div>
               </div>
             ))}
           </div>
         )}
       </div>
-
-      {/* Modal for approval/rejection */}
-      {showModal && selectedBooking && (
-        <div className="modal-overlay" onClick={() => setShowModal(false)}>
-          <div className="modal" onClick={(e) => e.stopPropagation()}>
-            <div className="modal-header">
-              <h3>
-                {actionType === 'approve' ? 'Approve' : 'Reject'} Booking
-              </h3>
-              <button 
-                className="close-btn"
-                onClick={() => setShowModal(false)}
-              >
-                ✕
-              </button>
-            </div>
-
-            <div className="modal-body">
-              <p className="booking-info">
-                <strong>{selectedBooking.service?.name}</strong> - {selectedBooking.user?.firstName} {selectedBooking.user?.lastName}
-              </p>
-              
-              <div className="form-group">
-                <label>Additional Notes (Optional)</label>
-                <textarea
-                  value={notes}
-                  onChange={(e) => setNotes(e.target.value)}
-                  placeholder="Add any notes about this approval/rejection..."
-                  rows="4"
-                />
-              </div>
-
-              <div className="modal-actions">
-                <button 
-                  className="btn-cancel"
-                  onClick={() => setShowModal(false)}
-                >
-                  Cancel
-                </button>
-                <button 
-                  className={actionType === 'approve' ? 'btn-approve' : 'btn-reject'}
-                  onClick={submitAction}
-                >
-                  {actionType === 'approve' ? 'Approve Booking' : 'Reject Booking'}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/pages/StaffDashboard.js
+++ b/frontend/src/pages/StaffDashboard.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import BookingActionModal from '../components/BookingActionModal';
+import { approvalAPI } from '../services/approvalApi';
 import '../styles/StaffDashboard.css';
 
 const StaffDashboard = () => {
@@ -9,6 +10,12 @@ const StaffDashboard = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [staffInfo, setStaffInfo] = useState(null);
+
+  const [selectedBooking, setSelectedBooking] = useState(null);
+  const [notes, setNotes] = useState('');
+  const [showModal, setShowModal] = useState(false);
+  const [actionType, setActionType] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -28,7 +35,7 @@ const StaffDashboard = () => {
       }
 
       setStaffInfo(userData);
-      fetchPendingBookings(userData.id, token);
+      fetchPendingBookings(userData.id);
     } catch (err) {
       console.error('Failed to parse stored user data:', err);
       localStorage.removeItem('token');
@@ -37,23 +44,10 @@ const StaffDashboard = () => {
     }
   }, [navigate]);
 
-  const fetchPendingBookings = async (staffId, token) => {
+  const fetchPendingBookings = async (staffId) => {
     try {
       setLoading(true);
-
-      const response = await axios.get(
-        `http://localhost:8080/api/approval/staff/${staffId}/pending`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      const bookingsData = Array.isArray(response.data)
-        ? response.data
-        : response.data?.data || [];
-
+      const bookingsData = await approvalAPI.getPendingBookingsByStaff(staffId);
       setBookings(bookingsData);
       setError('');
     } catch (err) {
@@ -105,6 +99,53 @@ const StaffDashboard = () => {
 
   const getStudentPhone = (booking) => {
     return booking.user?.phone || booking.phone || 'N/A';
+  };
+
+  const openActionModal = (booking, type) => {
+    setSelectedBooking(booking);
+    setActionType(type);
+    setNotes('');
+    setShowModal(true);
+    setError('');
+  };
+
+  const closeModal = () => {
+    if (submitting) return;
+    setShowModal(false);
+    setSelectedBooking(null);
+    setNotes('');
+    setActionType('');
+  };
+
+  const submitAction = async () => {
+    if (!selectedBooking || !staffInfo) return;
+
+    try {
+      setSubmitting(true);
+      setError('');
+
+      const payload = {
+        status: actionType === 'approve' ? 'approved' : 'rejected',
+        approvalNotes: notes,
+        staffId: staffInfo.id,
+      };
+
+      if (actionType === 'approve') {
+        await approvalAPI.approveBooking(selectedBooking.id, payload);
+      } else {
+        await approvalAPI.rejectBooking(selectedBooking.id, payload);
+      }
+
+      closeModal();
+      await fetchPendingBookings(staffInfo.id);
+    } catch (err) {
+      console.error(`Failed to ${actionType} booking:`, err);
+      const errorMsg =
+        err.response?.data?.error || `Failed to ${actionType} booking`;
+      setError(errorMsg);
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -182,11 +223,40 @@ const StaffDashboard = () => {
                     <span className="value">{formatDate(booking.createdAt)}</span>
                   </div>
                 </div>
+
+                <div className="booking-actions">
+                  <button
+                    className="btn-reject"
+                    onClick={() => openActionModal(booking, 'reject')}
+                  >
+                    Reject
+                  </button>
+
+                  <button
+                    className="btn-approve"
+                    onClick={() => openActionModal(booking, 'approve')}
+                  >
+                    Approve
+                  </button>
+                </div>
               </div>
             ))}
           </div>
         )}
       </div>
+
+      <BookingActionModal
+        show={showModal}
+        actionType={actionType}
+        selectedBooking={selectedBooking}
+        notes={notes}
+        onNotesChange={setNotes}
+        onClose={closeModal}
+        onSubmit={submitAction}
+        submitting={submitting}
+        getServiceName={getServiceName}
+        getStudentName={getStudentName}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/StaffDashboard.test.js
+++ b/frontend/src/pages/StaffDashboard.test.js
@@ -1,13 +1,15 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import axios from 'axios';
 import StaffDashboard from './StaffDashboard';
 
 jest.mock('axios');
+
+const mockNavigate = jest.fn();
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useNavigate: () => jest.fn(),
+  useNavigate: () => mockNavigate,
 }));
 
 describe('StaffDashboard Page Component', () => {
@@ -22,30 +24,41 @@ describe('StaffDashboard Page Component', () => {
   const mockBookings = [
     {
       id: 1,
-      userId: 2,
-      serviceId: 1,
-      serviceName: 'Main Library',
       status: 'pending',
       startTime: '2024-02-20T10:00:00Z',
       endTime: '2024-02-20T12:00:00Z',
       createdAt: '2024-02-15T10:00:00Z',
+      notes: 'Need projector access',
+      service: {
+        name: 'Main Library',
+      },
+      user: {
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        phone: '123-456-7890',
+      },
     },
     {
       id: 2,
-      userId: 3,
-      serviceId: 1,
-      serviceName: 'Study Room',
       status: 'pending',
-      startTime: '2024-02-20T14:00:00Z',
-      endTime: '2024-02-20T16:00:00Z',
-      createdAt: '2024-02-15T10:00:00Z',
+      startTime: '2024-02-21T14:00:00Z',
+      endTime: '2024-02-21T16:00:00Z',
+      createdAt: '2024-02-16T09:30:00Z',
+      notes: 'Group study session',
+      service: {
+        name: 'Study Room',
+      },
+      user: {
+        firstName: 'Jane',
+        lastName: 'Smith',
+        email: 'jane@example.com',
+        phone: '555-111-2222',
+      },
     },
   ];
 
   const renderStaffDashboard = () => {
-    localStorage.setItem('token', 'mock-token');
-    localStorage.setItem('user', JSON.stringify(mockStaff));
-
     render(
       <BrowserRouter>
         <StaffDashboard />
@@ -56,47 +69,50 @@ describe('StaffDashboard Page Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    mockNavigate.mockClear();
+
+    localStorage.setItem('token', 'mock-token');
+    localStorage.setItem('user', JSON.stringify(mockStaff));
+
     axios.get.mockResolvedValue({ data: mockBookings });
-    axios.put.mockResolvedValue({ data: { success: true } });
   });
 
-  test('redirects to login if no token', () => {
+  test('redirects to login if no token', async () => {
     localStorage.clear();
 
-    render(
-      <BrowserRouter>
-        <StaffDashboard />
-      </BrowserRouter>
-    );
-
-    // Navigation to login should occur
-  });
-
-  test('redirects to home if user is not staff', () => {
-    const notStaffUser = { ...mockStaff, role: 'student' };
-    localStorage.setItem('user', JSON.stringify(notStaffUser));
-    localStorage.setItem('token', 'mock-token');
-
-    render(
-      <BrowserRouter>
-        <StaffDashboard />
-      </BrowserRouter>
-    );
-
-    // Navigation to home should occur
-  });
-
-  test('renders staff dashboard', async () => {
     renderStaffDashboard();
 
     await waitFor(() => {
-      expect(screen.getByText(/Staff Dashboard|staff|Dashboard/i)).toBeInTheDocument();
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  test('redirects to home if user is not staff', async () => {
+    const notStaffUser = { ...mockStaff, role: 'student' };
+    localStorage.setItem('token', 'mock-token');
+    localStorage.setItem('user', JSON.stringify(notStaffUser));
+
+    renderStaffDashboard();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  test('renders staff dashboard heading and welcome text', async () => {
+    renderStaffDashboard();
+
+    expect(screen.getByText('Staff Dashboard')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Welcome, Staff Member/i)).toBeInTheDocument();
     });
   });
 
   test('displays loading state initially', () => {
     renderStaffDashboard();
-    // Loading might be brief
+
+    expect(screen.getByText(/Loading pending bookings.../i)).toBeInTheDocument();
   });
 
   test('fetches pending bookings on mount', async () => {
@@ -104,8 +120,12 @@ describe('StaffDashboard Page Component', () => {
 
     await waitFor(() => {
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/approval/staff'),
-        expect.any(Object)
+        'http://localhost:8080/api/approval/staff/1/pending',
+        {
+          headers: {
+            Authorization: 'Bearer mock-token',
+          },
+        }
       );
     });
   });
@@ -116,187 +136,97 @@ describe('StaffDashboard Page Component', () => {
     await waitFor(() => {
       expect(screen.getByText('Main Library')).toBeInTheDocument();
       expect(screen.getByText('Study Room')).toBeInTheDocument();
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
     });
   });
 
-  test('displays approve button for each pending booking', async () => {
+  test('shows pending bookings count badge', async () => {
     renderStaffDashboard();
 
     await waitFor(() => {
-      const approveButtons = screen.getAllByRole('button', { name: /approve/i });
-      expect(approveButtons.length).toBe(2);
+      expect(screen.getByText('2')).toBeInTheDocument();
     });
   });
 
-  test('displays reject button for each pending booking', async () => {
+  test('displays booking detail fields in cards', async () => {
     renderStaffDashboard();
 
     await waitFor(() => {
-      const rejectButtons = screen.getAllByRole('button', { name: /reject/i });
-      expect(rejectButtons.length).toBe(2);
-    });
-  });
-
-  test('opens modal when approve button clicked', async () => {
-    renderStaffDashboard();
-
-    await waitFor(() => {
-      expect(screen.getByText('Main Library')).toBeInTheDocument();
-    });
-
-    const approveButtons = screen.getAllByRole('button', { name: /approve/i });
-    fireEvent.click(approveButtons[0]);
-
-    await waitFor(() => {
-      expect(screen.getByText(/notes|approval/i)).toBeInTheDocument();
-    });
-  });
-
-  test('opens modal when reject button clicked', async () => {
-    renderStaffDashboard();
-
-    await waitFor(() => {
-      expect(screen.getByText('Main Library')).toBeInTheDocument();
-    });
-
-    const rejectButtons = screen.getAllByRole('button', { name: /reject/i });
-    fireEvent.click(rejectButtons[0]);
-
-    await waitFor(() => {
-      expect(screen.getByText(/notes|reason/i)).toBeInTheDocument();
-    });
-  });
-
-  test('submits approval action with notes', async () => {
-    renderStaffDashboard();
-
-    await waitFor(() => {
-      expect(screen.getByText('Main Library')).toBeInTheDocument();
-    });
-
-    const approveButtons = screen.getAllByRole('button', { name: /approve/i });
-    fireEvent.click(approveButtons[0]);
-
-    await waitFor(() => {
-      const notesInput = screen.getByPlaceholderText(/notes/i);
-      expect(notesInput).toBeInTheDocument();
-    });
-
-    const notesInput = screen.getByPlaceholderText(/notes/i);
-    await userEvent.type(notesInput, 'Approved');
-
-    const submitButton = screen.getByRole('button', { name: /submit|confirm/i });
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith(
-        expect.stringContaining('/approve'),
-        expect.any(Object),
-        expect.any(Object)
-      );
-    });
-  });
-
-  test('submits rejection action with notes', async () => {
-    renderStaffDashboard();
-
-    await waitFor(() => {
-      expect(screen.getByText('Main Library')).toBeInTheDocument();
-    });
-
-    const rejectButtons = screen.getAllByRole('button', { name: /reject/i });
-    fireEvent.click(rejectButtons[0]);
-
-    await waitFor(() => {
-      const notesInput = screen.getByPlaceholderText(/notes/i);
-      expect(notesInput).toBeInTheDocument();
-    });
-
-    const notesInput = screen.getByPlaceholderText(/notes/i);
-    await userEvent.type(notesInput, 'Not available');
-
-    const submitButton = screen.getByRole('button', { name: /submit|confirm/i });
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(axios.put).toHaveBeenCalledWith(
-        expect.stringContaining('/reject'),
-        expect.any(Object),
-        expect.any(Object)
-      );
+      expect(screen.getAllByText('Student Name:').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Email:').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Phone:').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Start Time:').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('End Time:').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Reason:').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Requested:').length).toBeGreaterThan(0);
     });
   });
 
   test('displays error message on fetch failure', async () => {
-    axios.get.mockRejectedValueOnce(new Error('Failed to load'));
+    axios.get.mockRejectedValueOnce({
+      response: {
+        data: {
+          error: 'Failed to load pending bookings',
+        },
+      },
+    });
 
     renderStaffDashboard();
 
     await waitFor(() => {
-      const errorText = screen.queryByText(/failed|error/i);
-      // Depending on implementation
+      expect(
+        screen.getByText('Failed to load pending bookings')
+      ).toBeInTheDocument();
     });
   });
 
-  test('displays error message on action failure', async () => {
-    axios.put.mockRejectedValueOnce(new Error('Failed to approve'));
+  test('displays empty state when there are no pending bookings', async () => {
+    axios.get.mockResolvedValueOnce({ data: [] });
+
+    renderStaffDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('No pending bookings')).toBeInTheDocument();
+      expect(
+        screen.getByText('There are currently no bookings awaiting review.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('handles API response wrapped in data property', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        data: mockBookings,
+      },
+    });
 
     renderStaffDashboard();
 
     await waitFor(() => {
       expect(screen.getByText('Main Library')).toBeInTheDocument();
-    });
-
-    const approveButtons = screen.getAllByRole('button', { name: /approve/i });
-    fireEvent.click(approveButtons[0]);
-
-    await waitFor(() => {
-      const notesInput = screen.getByPlaceholderText(/notes/i);
-      expect(notesInput).toBeInTheDocument();
-    });
-
-    const submitButton = screen.getByRole('button', { name: /submit|confirm/i });
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      const errorMsg = screen.queryByText(/failed|error/i);
-      // Error message should appear
+      expect(screen.getByText('Study Room')).toBeInTheDocument();
     });
   });
 
-  test('closes modal after successful action', async () => {
+  test('falls back gracefully when booking fields are missing', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: 99,
+          startTime: null,
+          endTime: null,
+          createdAt: null,
+          notes: '',
+        },
+      ],
+    });
+
     renderStaffDashboard();
 
     await waitFor(() => {
-      expect(screen.getByText('Main Library')).toBeInTheDocument();
+      expect(screen.getByText('Service Not Available')).toBeInTheDocument();
+      expect(screen.getAllByText('N/A').length).toBeGreaterThan(0);
     });
-
-    const approveButtons = screen.getAllByRole('button', { name: /approve/i });
-    fireEvent.click(approveButtons[0]);
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(/notes/i)).toBeInTheDocument();
-    });
-
-    const submitButton = screen.getByRole('button', { name: /submit|confirm/i });
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      // Modal should close
-      const modal = screen.queryByPlaceholderText(/notes/i);
-      // Depends on re-render timing
-    });
-  });
-
-  test('displays booking details in card', async () => {
-    renderStaffDashboard();
-
-    await waitFor(() => {
-      expect(screen.getByText('Main Library')).toBeInTheDocument();
-    });
-
-    // Booking details should be visible
-    const cards = screen.getAllByText(/2024-02-20T/);
-    expect(cards.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/pages/StaffDashboard.test.js
+++ b/frontend/src/pages/StaffDashboard.test.js
@@ -1,9 +1,16 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
-import axios from 'axios';
 import StaffDashboard from './StaffDashboard';
+import { approvalAPI } from '../services/approvalApi';
 
-jest.mock('axios');
+jest.mock('../services/approvalApi', () => ({
+  approvalAPI: {
+    getPendingBookingsByStaff: jest.fn(),
+    approveBooking: jest.fn(),
+    rejectBooking: jest.fn(),
+  },
+}));
 
 const mockNavigate = jest.fn();
 
@@ -74,7 +81,9 @@ describe('StaffDashboard Page Component', () => {
     localStorage.setItem('token', 'mock-token');
     localStorage.setItem('user', JSON.stringify(mockStaff));
 
-    axios.get.mockResolvedValue({ data: mockBookings });
+    approvalAPI.getPendingBookingsByStaff.mockResolvedValue(mockBookings);
+    approvalAPI.approveBooking.mockResolvedValue({ data: { success: true } });
+    approvalAPI.rejectBooking.mockResolvedValue({ data: { success: true } });
   });
 
   test('redirects to login if no token', async () => {
@@ -109,95 +118,172 @@ describe('StaffDashboard Page Component', () => {
     });
   });
 
-  test('displays loading state initially', () => {
-    renderStaffDashboard();
-
-    expect(screen.getByText(/Loading pending bookings.../i)).toBeInTheDocument();
-  });
-
   test('fetches pending bookings on mount', async () => {
     renderStaffDashboard();
 
     await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith(
-        'http://localhost:8080/api/approval/staff/1/pending',
-        {
-          headers: {
-            Authorization: 'Bearer mock-token',
-          },
-        }
-      );
+      expect(approvalAPI.getPendingBookingsByStaff).toHaveBeenCalledWith(1);
     });
   });
 
-  test('displays pending bookings after loading', async () => {
+  test('shows approve and reject buttons for each booking', async () => {
+    renderStaffDashboard();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Approve' })).toHaveLength(2);
+      expect(screen.getAllByRole('button', { name: 'Reject' })).toHaveLength(2);
+    });
+  });
+
+  test('opens approve modal when approve button is clicked', async () => {
+    const user = userEvent.setup();
     renderStaffDashboard();
 
     await waitFor(() => {
       expect(screen.getByText('Main Library')).toBeInTheDocument();
-      expect(screen.getByText('Study Room')).toBeInTheDocument();
-      expect(screen.getByText('John Doe')).toBeInTheDocument();
-      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
     });
+
+    await user.click(screen.getAllByRole('button', { name: 'Approve' })[0]);
+
+    expect(await screen.findByText('Approve Booking')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/Add any notes about this approval or rejection/i)
+    ).toBeInTheDocument();
   });
 
-  test('shows pending bookings count badge', async () => {
+  test('opens reject modal when reject button is clicked', async () => {
+    const user = userEvent.setup();
     renderStaffDashboard();
 
     await waitFor(() => {
-      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('Main Library')).toBeInTheDocument();
     });
+
+    await user.click(screen.getAllByRole('button', { name: 'Reject' })[0]);
+
+    expect(await screen.findByText('Reject Booking')).toBeInTheDocument();
   });
 
-  test('displays booking detail fields in cards', async () => {
+  test('allows user to type notes in modal', async () => {
+    const user = userEvent.setup();
     renderStaffDashboard();
 
     await waitFor(() => {
-      expect(screen.getAllByText('Student Name:').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('Email:').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('Phone:').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('Start Time:').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('End Time:').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('Reason:').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('Requested:').length).toBeGreaterThan(0);
+      expect(screen.getByText('Main Library')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole('button', { name: 'Approve' })[0]);
+
+    const textarea = await screen.findByPlaceholderText(
+      /Add any notes about this approval or rejection/i
+    );
+
+    await user.type(textarea, 'Approved by staff');
+
+    expect(textarea).toHaveValue('Approved by staff');
+  });
+
+  test('submits approval action successfully', async () => {
+    const user = userEvent.setup();
+    renderStaffDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Main Library')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole('button', { name: 'Approve' })[0]);
+
+    const textarea = await screen.findByPlaceholderText(
+      /Add any notes about this approval or rejection/i
+    );
+    await user.type(textarea, 'Looks good');
+
+    await user.click(screen.getByRole('button', { name: 'Approve Booking' }));
+
+    await waitFor(() => {
+      expect(approvalAPI.approveBooking).toHaveBeenCalledWith(1, {
+        status: 'approved',
+        approvalNotes: 'Looks good',
+        staffId: 1,
+      });
+    });
+
+    await waitFor(() => {
+      expect(approvalAPI.getPendingBookingsByStaff).toHaveBeenCalledTimes(2);
     });
   });
 
-  test('displays error message on fetch failure', async () => {
-    axios.get.mockRejectedValueOnce({
+  test('submits rejection action successfully', async () => {
+    const user = userEvent.setup();
+    renderStaffDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Main Library')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole('button', { name: 'Reject' })[0]);
+
+    const textarea = await screen.findByPlaceholderText(
+      /Add any notes about this approval or rejection/i
+    );
+    await user.type(textarea, 'Conflicting schedule');
+
+    await user.click(screen.getByRole('button', { name: 'Reject Booking' }));
+
+    await waitFor(() => {
+      expect(approvalAPI.rejectBooking).toHaveBeenCalledWith(1, {
+        status: 'rejected',
+        approvalNotes: 'Conflicting schedule',
+        staffId: 1,
+      });
+    });
+  });
+
+  test('closes modal when cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    renderStaffDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Main Library')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole('button', { name: 'Approve' })[0]);
+
+    expect(await screen.findByText('Approve Booking')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Approve Booking')).not.toBeInTheDocument();
+    });
+  });
+
+  test('closes modal when overlay is clicked', async () => {
+    const user = userEvent.setup();
+    renderStaffDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Main Library')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole('button', { name: 'Approve' })[0]);
+
+    expect(await screen.findByText('Approve Booking')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('booking-action-modal-overlay'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Approve Booking')).not.toBeInTheDocument();
+    });
+  });
+
+  test('shows error message if approval submission fails', async () => {
+    const user = userEvent.setup();
+    approvalAPI.approveBooking.mockRejectedValueOnce({
       response: {
         data: {
-          error: 'Failed to load pending bookings',
+          error: 'Failed to approve booking',
         },
-      },
-    });
-
-    renderStaffDashboard();
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('Failed to load pending bookings')
-      ).toBeInTheDocument();
-    });
-  });
-
-  test('displays empty state when there are no pending bookings', async () => {
-    axios.get.mockResolvedValueOnce({ data: [] });
-
-    renderStaffDashboard();
-
-    await waitFor(() => {
-      expect(screen.getByText('No pending bookings')).toBeInTheDocument();
-      expect(
-        screen.getByText('There are currently no bookings awaiting review.')
-      ).toBeInTheDocument();
-    });
-  });
-
-  test('handles API response wrapped in data property', async () => {
-    axios.get.mockResolvedValueOnce({
-      data: {
-        data: mockBookings,
       },
     });
 
@@ -205,28 +291,37 @@ describe('StaffDashboard Page Component', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Main Library')).toBeInTheDocument();
-      expect(screen.getByText('Study Room')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole('button', { name: 'Approve' })[0]);
+    await user.click(screen.getByRole('button', { name: 'Approve Booking' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to approve booking')).toBeInTheDocument();
     });
   });
 
-  test('falls back gracefully when booking fields are missing', async () => {
-    axios.get.mockResolvedValueOnce({
-      data: [
-        {
-          id: 99,
-          startTime: null,
-          endTime: null,
-          createdAt: null,
-          notes: '',
+  test('shows error message if rejection submission fails', async () => {
+    const user = userEvent.setup();
+    approvalAPI.rejectBooking.mockRejectedValueOnce({
+      response: {
+        data: {
+          error: 'Failed to reject booking',
         },
-      ],
+      },
     });
 
     renderStaffDashboard();
 
     await waitFor(() => {
-      expect(screen.getByText('Service Not Available')).toBeInTheDocument();
-      expect(screen.getAllByText('N/A').length).toBeGreaterThan(0);
+      expect(screen.getByText('Main Library')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole('button', { name: 'Reject' })[0]);
+    await user.click(screen.getByRole('button', { name: 'Reject Booking' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to reject booking')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/services/approvalApi.js
+++ b/frontend/src/services/approvalApi.js
@@ -1,0 +1,42 @@
+import axios from 'axios';
+
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080/api';
+
+const getAuthHeaders = () => {
+  const token = localStorage.getItem('token');
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  };
+};
+
+export const approvalAPI = {
+  getPendingBookingsByStaff: async (staffId) => {
+    const response = await axios.get(
+      `${API_BASE_URL}/approval/staff/${staffId}/pending`,
+      getAuthHeaders()
+    );
+
+    return Array.isArray(response.data) ? response.data : response.data?.data || [];
+  },
+
+  approveBooking: async (bookingId, payload) => {
+    return axios.put(
+      `${API_BASE_URL}/approval/bookings/${bookingId}/approve`,
+      payload,
+      getAuthHeaders()
+    );
+  },
+
+  rejectBooking: async (bookingId, payload) => {
+    return axios.put(
+      `${API_BASE_URL}/approval/bookings/${bookingId}/reject`,
+      payload,
+      getAuthHeaders()
+    );
+  },
+};
+
+export default approvalAPI;

--- a/frontend/src/styles/StaffDashboard.css
+++ b/frontend/src/styles/StaffDashboard.css
@@ -203,7 +203,7 @@
   color: white;
 }
 
-.btn-approve:hover {
+.btn-approve:hover:not(:disabled) {
   transform: scale(1.02);
   box-shadow: 0 5px 15px rgba(102, 126, 234, 0.4);
 }
@@ -214,9 +214,16 @@
   border: 2px solid #dc3545;
 }
 
-.btn-reject:hover {
+.btn-reject:hover:not(:disabled) {
   background-color: #dc3545;
   color: white;
+}
+
+button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
 }
 
 /* Modal Styles */
@@ -226,19 +233,20 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(0, 0, 0, 0.55);
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 1000;
   animation: fadeIn 0.3s ease-out;
+  padding: 20px;
 }
 
 .modal {
   background: white;
-  border-radius: 12px;
-  max-width: 500px;
-  width: 90%;
+  border-radius: 14px;
+  max-width: 520px;
+  width: 100%;
   max-height: 80vh;
   overflow-y: auto;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
@@ -249,7 +257,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 25px;
+  padding: 22px 25px;
   border-bottom: 1px solid #e9ecef;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
@@ -261,22 +269,21 @@
 }
 
 .close-btn {
-  background: none;
+  background: transparent;
   border: none;
   color: white;
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   cursor: pointer;
-  padding: 0;
-  width: 30px;
-  height: 30px;
+  width: 34px;
+  height: 34px;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s ease;
+  border-radius: 50%;
 }
 
-.close-btn:hover {
-  transform: scale(1.1);
+.close-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.15);
 }
 
 .modal-body {
@@ -287,7 +294,6 @@
   background-color: #f8f9fa;
   padding: 15px;
   border-radius: 8px;
-  margin-bottom: 20px;
   margin: 0 0 20px 0;
   color: #555;
 }
@@ -313,6 +319,7 @@
   font-size: 0.95rem;
   resize: vertical;
   transition: border-color 0.3s ease;
+  box-sizing: border-box;
 }
 
 .form-group textarea:focus {
@@ -329,7 +336,6 @@
 .modal-actions button {
   flex: 1;
   padding: 12px 20px;
-  border: none;
   border-radius: 8px;
   font-size: 1rem;
   font-weight: 600;
@@ -343,7 +349,7 @@
   border: 2px solid #e9ecef;
 }
 
-.btn-cancel:hover {
+.btn-cancel:hover:not(:disabled) {
   background-color: #e9ecef;
 }
 
@@ -403,6 +409,10 @@
   }
 
   .modal {
-    width: 95%;
+    width: 100%;
+  }
+
+  .modal-actions {
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
As a staff member, I want to approve or reject pending booking requests from the staff dashboard, so that I can review service reservations efficiently and update their status with optional notes.

Implemented Staff Approve & Reject Booking Actions:
- Added Approve and Reject action buttons to each pending booking card in the staff dashboard.
- Created a reusable BookingActionModal component to handle approval and rejection flows.
- Added modal-based confirmation for both actions so staff can review the selected booking before submitting a decision.
- Allowed staff members to enter optional approval or rejection notes before submitting.
- Added a dedicated approvalApi service file to separate approval-related backend requests from UI code.
- Sent approve and reject requests to backend approval endpoints with booking ID, updated status, approval notes, and staff ID.
- Included bearer token authorization in approval action requests.
- Refreshed the pending bookings list after successful approval or rejection to keep the dashboard up to date.
- Added loading protection during submission to prevent duplicate requests.
- Added frontend unit tests for action button rendering, modal opening, note entry, approve flow, reject flow, modal closing, overlay closing, and submission error handling.