### PR TITLE
Added role-based navbar link rendering

### DIFF
--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import '../styles/Navbar.css';
+import { getRoleBasedLinks } from '../utils/navbarLinks';
 
 function Navbar() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -11,13 +12,21 @@ function Navbar() {
     const token = localStorage.getItem('token');
     const user = localStorage.getItem('user');
     if (token && user) {
-      setIsLoggedIn(true);
-      setCurrentUser(JSON.parse(user));
-    } else {
+      try {
+        const parsedUser = JSON.parse(user);
+        setIsLoggedIn(true);
+        setCurrentUser(parsedUser);
+      } catch (error) {
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
       setIsLoggedIn(false);
       setCurrentUser(null);
     }
-  };
+  } else {
+    setIsLoggedIn(false);
+    setCurrentUser(null);
+  }
+};
 
   useEffect(() => {
     // Check auth status on mount
@@ -53,6 +62,7 @@ function Navbar() {
     
     navigate('/');
   };
+  const { navLinks, authLinks } = getRoleBasedLinks(isLoggedIn, currentUser);
 
   return (
     <nav className="navbar">
@@ -61,27 +71,46 @@ function Navbar() {
           🏫 Smart Campus Services
         </Link>
         <div className="navbar-menu">
-          <Link to="/" className="nav-link">Home</Link>
-          <Link to="/services" className="nav-link">Services</Link>
-          {isLoggedIn && currentUser?.role === 'student' && <Link to="/bookings" className="nav-link">My Bookings</Link>}
-          {isLoggedIn && currentUser?.role === 'staff' && <Link to="/dashboard/staff" className="nav-link">Staff Dashboard</Link>}
-          {isLoggedIn && currentUser?.role === 'admin' && <Link to="/dashboard/admin" className="nav-link">Admin Dashboard</Link>}
-          
-          <div className="navbar-auth">
-            {isLoggedIn ? (
-              <>
-                <span className="welcome-text">Welcome, {currentUser?.firstName}</span>
-                {currentUser?.role === 'student' && <Link to={`/profile/${currentUser?.id}`} className="nav-link">Profile</Link>}
-                <button onClick={handleLogout} className="logout-btn">Logout</button>
-              </>
-            ) : (
-              <>
-                <Link to="/login" className="nav-link">Login</Link>
-                <Link to="/register" className="nav-link register-btn">Register</Link>
-              </>
-            )}
-          </div>
-        </div>
+  {navLinks.map((link) => (
+    <Link key={link.label} to={link.path} className="nav-link">
+      {link.label}
+    </Link>
+  ))}
+
+  <div className="navbar-auth">
+    {isLoggedIn ? (
+      <>
+        <span className="welcome-text">Welcome, {currentUser?.firstName}</span>
+
+        {authLinks.map((link) => (
+          <Link
+            key={link.label}
+            to={link.path}
+            className={`nav-link ${link.className || ''}`.trim()}
+          >
+            {link.label}
+          </Link>
+        ))}
+
+        <button onClick={handleLogout} className="logout-btn">
+          Logout
+        </button>
+      </>
+    ) : (
+      <>
+        {authLinks.map((link) => (
+          <Link
+            key={link.label}
+            to={link.path}
+            className={`nav-link ${link.className || ''}`.trim()}
+          >
+            {link.label}
+          </Link>
+        ))}
+      </>
+    )}
+  </div>
+</div>
       </div>
     </nav>
   );

--- a/frontend/src/components/Navbar.test.js
+++ b/frontend/src/components/Navbar.test.js
@@ -1,6 +1,13 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
-import Navbar from './components/Navbar';
+import Navbar from './Navbar';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
 
 describe('Navbar Component', () => {
   const renderNavbar = () => {
@@ -11,31 +18,125 @@ describe('Navbar Component', () => {
     );
   };
 
+  const setLoggedOutState = () => {
+    localStorage.clear();
+  };
+
+  const setLoggedInUser = (user) => {
+    localStorage.setItem('token', 'mock-token');
+    localStorage.setItem('user', JSON.stringify(user));
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+    mockNavigate.mockClear();
+  });
+
   test('renders navigation bar', () => {
     renderNavbar();
-    const nav = screen.getByRole('navigation');
-    expect(nav).toBeInTheDocument();
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
   });
 
-  test('displays Home link', () => {
+  test('shows guest links when user is not logged in', async () => {
+    setLoggedOutState();
     renderNavbar();
-    expect(screen.getByText(/Home/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Home')).toBeInTheDocument();
+      expect(screen.getByText('Services')).toBeInTheDocument();
+      expect(screen.getByText('Login')).toBeInTheDocument();
+      expect(screen.getByText('Register')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('My Bookings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Staff Dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByText('Admin Dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByText('Logout')).not.toBeInTheDocument();
   });
 
-  test('displays Services link', () => {
+  test('shows student links when logged in as student', async () => {
+    setLoggedInUser({
+      id: 1,
+      firstName: 'Keerthi',
+      role: 'student',
+    });
+
     renderNavbar();
-    expect(screen.getByText(/Services/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('My Bookings')).toBeInTheDocument();
+      expect(screen.getByText('Profile')).toBeInTheDocument();
+      expect(screen.getByText('Logout')).toBeInTheDocument();
+      expect(screen.getByText(/Welcome, Keerthi/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Staff Dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByText('Admin Dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByText('Login')).not.toBeInTheDocument();
+    expect(screen.queryByText('Register')).not.toBeInTheDocument();
   });
 
-  test('displays Bookings link', () => {
+  test('shows staff links when logged in as staff', async () => {
+    setLoggedInUser({
+      id: 2,
+      firstName: 'Alex',
+      role: 'staff',
+    });
+
     renderNavbar();
-    expect(screen.getByText(/Bookings/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Staff Dashboard')).toBeInTheDocument();
+      expect(screen.getByText('Logout')).toBeInTheDocument();
+      expect(screen.getByText(/Welcome, Alex/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('My Bookings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Profile')).not.toBeInTheDocument();
+    expect(screen.queryByText('Admin Dashboard')).not.toBeInTheDocument();
   });
 
-  test('navigation links are clickable', () => {
+  test('shows admin links when logged in as admin', async () => {
+    setLoggedInUser({
+      id: 3,
+      firstName: 'Jordan',
+      role: 'admin',
+    });
+
     renderNavbar();
-    const homeLink = screen.getByRole('link', { name: /Home/i });
-    expect(homeLink).toBeInTheDocument();
-    expect(homeLink.href).toContain('/');
+
+    await waitFor(() => {
+      expect(screen.getByText('Admin Dashboard')).toBeInTheDocument();
+      expect(screen.getByText('Logout')).toBeInTheDocument();
+      expect(screen.getByText(/Welcome, Jordan/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('My Bookings')).not.toBeInTheDocument();
+    expect(screen.queryByText('Profile')).not.toBeInTheDocument();
+    expect(screen.queryByText('Staff Dashboard')).not.toBeInTheDocument();
+  });
+
+  test('logout clears storage and navigates home', async () => {
+    setLoggedInUser({
+      id: 1,
+      firstName: 'Keerthi',
+      role: 'student',
+    });
+
+    renderNavbar();
+
+    const logoutButton = await screen.findByText('Logout');
+    fireEvent.click(logoutButton);
+
+    expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('user')).toBeNull();
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  test('home link points to root route', async () => {
+    renderNavbar();
+    const homeLink = await screen.findByRole('link', { name: 'Home' });
+    expect(homeLink.getAttribute('href')).toBe('/');
   });
 });

--- a/frontend/src/utils/navbarLinks.js
+++ b/frontend/src/utils/navbarLinks.js
@@ -1,0 +1,33 @@
+export const getRoleBasedLinks = (isLoggedIn, currentUser) => {
+  const baseLinks = [
+    { label: 'Home', path: '/' },
+    { label: 'Services', path: '/services' },
+  ];
+
+  if (!isLoggedIn || !currentUser) {
+    return {
+      navLinks: baseLinks,
+      authLinks: [
+        { label: 'Login', path: '/login' },
+        { label: 'Register', path: '/register', className: 'register-btn' },
+      ],
+    };
+  }
+
+  const roleLinks = {
+    student: [{ label: 'My Bookings', path: '/bookings' }],
+    staff: [{ label: 'Staff Dashboard', path: '/dashboard/staff' }],
+    admin: [{ label: 'Admin Dashboard', path: '/dashboard/admin' }],
+  };
+
+  const authLinks = [
+    ...(currentUser.role === 'student'
+      ? [{ label: 'Profile', path: `/profile/${currentUser.id}` }]
+      : []),
+  ];
+
+  return {
+    navLinks: [...baseLinks, ...(roleLinks[currentUser.role] || [])],
+    authLinks,
+  };
+};


### PR DESCRIPTION
As a user, I want the navbar to display links based on my role, so that I only see navigation options relevant to my account and permissions.

Implemented Navbar Role-Based Link Rendering:

- Added role-based navbar rendering so navigation links change dynamically based on whether the user is a guest, student, staff member, or admin.
- Created a dedicated navbarLinks helper file to centralize role-specific navigation configuration and keep the navbar component cleaner and easier to maintain.
- Displayed common navigation links such as Home and Services for all users regardless of authentication state.
- Showed guest-only authentication links such as Login and Register when no user is logged in.
- Displayed student-specific links such as My Bookings and Profile after login.
- Displayed a Staff Dashboard link for authenticated staff users.
- Displayed an Admin Dashboard link for authenticated admin users.
- Added welcome text for authenticated users using the logged-in user’s stored information.
- Improved navbar authentication handling by safely parsing stored user data and resetting invalid session data when needed.
- Preserved logout functionality in the navbar and ensured logout clears local authentication data and redirects users appropriately.
- Wrote frontend unit tests to verify correct navbar rendering for guest, student, staff, and admin roles.
- Added tests for logout behavior and for showing only the navigation options relevant to the current user role.